### PR TITLE
fix #7

### DIFF
--- a/knnbox/datastore/datastore.py
+++ b/knnbox/datastore/datastore.py
@@ -152,12 +152,10 @@ class Datastore:
         # we open config file and get the shape
         config = read_config(self.path)
         
-        shape = config["data_infos"][filename]["faiss_index_shape"]
         if not hasattr(self, "faiss_index") or self.faiss_index is None:
             self.faiss_index = {}
         self.faiss_index[filename] = load_faiss_index(
                         path = index_path,
-                        shape = shape,
                         n_probe = 32,
                         move_to_gpu = move_to_gpu,
                         verbose=verbose
@@ -189,15 +187,6 @@ class Datastore:
                     use_gpu=use_gpu,
                     verbose=verbose
                     )
-        
-        # wrtie the shape information to the config file
-        config = read_config(self.path)
-        if do_pca:
-            config["data_infos"][name]["faiss_index_shape"] = \
-                        list(self.datas[name].shape[:-1]) + [pca_dim]
-        else:
-            config["data_infos"][name]["faiss_index_shape"] = self.datas[name].shape
-        write_config(self.path, config)
 
 
  

--- a/knnbox/datastore/utils.py
+++ b/knnbox/datastore/utils.py
@@ -146,7 +146,7 @@ def build_faiss_index(
 
 
 
-def load_faiss_index(path, shape, n_probe,
+def load_faiss_index(path, n_probe,
             move_to_gpu=True, verbose=False):
     r"""
     load the faiss index"""
@@ -170,7 +170,7 @@ def load_faiss_index(path, shape, n_probe,
         index = faiss.index_cpu_to_gpu(res, 0, index, co)
     if verbose:
         print("  > reading index took {} s".format(time.time()-start_time))
-        print("  > the datastore shape is ", shape)
+        print("  > the datastore shape is ", (index.ntotal, index.d))
     index.nprobe = n_probe
     print("[Finish Loading Faiss Index Successfully ^_^]")
     return index

--- a/knnbox/datastore/utils.py
+++ b/knnbox/datastore/utils.py
@@ -170,6 +170,11 @@ def load_faiss_index(path, n_probe,
         index = faiss.index_cpu_to_gpu(res, 0, index, co)
     if verbose:
         print("  > reading index took {} s".format(time.time()-start_time))
+        # Print all vector transforms
+        if isinstance(index,faiss.swigfaiss_avx2.IndexPreTransform):
+            print(f"    > {index.chain.size()} pre-transform is found")
+            for i in range(index.chain.size()):
+                print(f"    > pre-transform: {index.chain.at(i).d_in} -> {index.chain.at(i).d_out}")
         print("  > the datastore shape is ", (index.ntotal, index.d))
     index.nprobe = n_probe
     print("[Finish Loading Faiss Index Successfully ^_^]")


### PR DESCRIPTION
Fixed #7 
1. Remove code related to `faiss_index_shape` in `load_faiss_index` and `build_faiss_index` in `datastore.py`
2. Use shape from Index object in `load_faiss_index` in `utils.py`
3. Display all pre transforms in the index object
Sample output
```
[Start Loading Faiss Index]
  > reading index took 0.23750877380371094 s
    > 1 pre-transform is found
    > pre-transform: 1024 -> 256
  > the datastore shape is  (524374, 1024)
[Finish Loading Faiss Index Successfully ^_^]
```

Alongside the "How to reproduce", this fix is also tested on vanilla-knn-mt and greedy-merge-knn-mt scripts.