### PR TITLE
用一个优雅的方法来保存combiner

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -233,6 +233,10 @@ def train(args, trainer, task, epoch_itr):
 
     # reset epoch-level meters
     metrics.reset_meters("train")
+
+    if hasattr(trainer.model, "after_train_hook"):
+        trainer.model.after_train_hook()
+        
     return valid_losses, should_stop
 
 


### PR DESCRIPTION
呃，整一个稍微优雅一点的方法，用于在训练结束之后保存训练的combiner，或者是推理之后输出一些统计数据。
在fairseq_cli/train.py的235行后，加上

```python
 if hasattr(trainer.model, "after_train_hook"):
    trainer.model.after_train_hook()
```

除此之外，还有在knnbox-scripts/common/generate.py的_main函数最后return scorer之前加上（这个没有包含在这个pr中）

```python
for model in models:
    if hasattr(model, "after_inference_hook"):
        model.after_inference_hook()
```

这对于其他使用可训练的combiner、或者想要inference过程中统计一些metrics，只需要在模型中定义after_train_hook和after_inference_hook方法，就可以在训练/测试结束，执行一段指定的代码，用来保存训练的combiner或者输出统计的metrics

应该很有用！
